### PR TITLE
fix(object-attr): 修复模型属性构件，多行字符串和markdown输入框不对齐的问题

### DIFF
--- a/bricks/forms/src/cmdb-object-attr-value/components/ObjectAttrStr.tsx
+++ b/bricks/forms/src/cmdb-object-attr-value/components/ObjectAttrStr.tsx
@@ -33,8 +33,10 @@ interface ObjectAttrStrProps {
 }
 
 export function ObjectAttrStr(props: ObjectAttrStrProps): React.ReactElement {
+  props.value.mode = props.value.mode || "default";
+
   const [popoverVisible, setPopoverVisible] = React.useState(false);
-  const [startValue, setStartValue] = React.useState(1);
+
   const [value, setValue] = React.useState<Partial<StrValueType>>({
     mode: "default",
     default_type: "value",
@@ -43,6 +45,7 @@ export function ObjectAttrStr(props: ObjectAttrStrProps): React.ReactElement {
     prefix: "",
     default: "",
   });
+  const [startValue, setStartValue] = React.useState(1);
 
   React.useEffect(() => {
     !isNil(props.value) && setValue(props.value);
@@ -68,21 +71,27 @@ export function ObjectAttrStr(props: ObjectAttrStrProps): React.ReactElement {
   const handleStrDefaultTypeChange = (default_type: string) => {
     if (default_type === "function") {
       handleValueChange({ ...value, default_type, default: "guid()" });
+    } else if (
+      value.default_type !== default_type &&
+      ["series-number", "auto-increment-id"].includes(default_type)
+    ) {
+      handleValueChange({
+        ...value,
+        default_type,
+        default: "",
+        start_value: 1,
+      });
     } else {
       handleValueChange({ ...value, default_type, default: "" });
     }
   };
 
   const handleVisibleChange = () => {
+    setStartValue(value.start_value);
     setPopoverVisible(true);
   };
   const hidePopover = () => {
-    setStartValue(1);
     setPopoverVisible(false);
-    handleValueChange({
-      ...value,
-      start_value: 1,
-    });
   };
 
   const handleStartValueChange = () => {
@@ -93,10 +102,7 @@ export function ObjectAttrStr(props: ObjectAttrStrProps): React.ReactElement {
     setStartValue(e);
   };
 
-  const getPopoverContent = (detail: {
-    prefix: string;
-    series_number_length?: number;
-  }): React.ReactNode => (
+  const getPopoverContent = (): React.ReactNode => (
     <>
       <Row style={{ width: 200, marginBottom: 15 }} align="middle" type="flex">
         <Col span={6}>起始值</Col>
@@ -183,6 +189,7 @@ export function ObjectAttrStr(props: ObjectAttrStrProps): React.ReactElement {
         <Row gutter={15}>
           <Col span={8}>
             <InputNumber
+              placeholder="流水号长度"
               value={value.series_number_length}
               onChange={(e) => {
                 handleValueChange({ ...value, series_number_length: e });
@@ -206,7 +213,6 @@ export function ObjectAttrStr(props: ObjectAttrStrProps): React.ReactElement {
             <Popover
               content={getPopoverContent({
                 prefix: value.prefix,
-                series_number_length: value.series_number_length,
               })}
               trigger="click"
               visible={popoverVisible}

--- a/bricks/forms/src/cmdb-object-attr-value/components/ObjectAttrStr.tsx
+++ b/bricks/forms/src/cmdb-object-attr-value/components/ObjectAttrStr.tsx
@@ -259,7 +259,15 @@ export function ObjectAttrStr(props: ObjectAttrStrProps): React.ReactElement {
                 <Option value="series-number">流水号</Option>
               </Select>
             </Col>
-            <Col span={value.default_type === "series-number" ? 18 : 12}>
+            <Col
+              span={value.default_type === "series-number" ? 18 : 12}
+              style={{
+                marginTop:
+                  value.mode === "multiple-lines" || value.mode === "markdown"
+                    ? "-5px"
+                    : "0px",
+              }}
+            >
               {getDefaultControl()}
             </Col>
           </Row>

--- a/bricks/forms/src/cmdb-object-attr-value/index.tsx
+++ b/bricks/forms/src/cmdb-object-attr-value/index.tsx
@@ -185,7 +185,7 @@ export class CmdbObjectAttrValueElement extends FormItemElement {
   ): void => {
     try {
       if (
-        this.hasValue(value) &&
+        !isNil(value) &&
         value.type === "str" &&
         value.default_type === "series-number"
       ) {


### PR DESCRIPTION
fixes INSTANCE-1373

## 依赖检查

组件之间的依赖声明，是微服务组件架构下的重要信息，请确保其正确性。

请勾选以下两组选项其中之一：

- [x] 本次 MR **没有使用**上游组件（例如框架、后台组件等）的较新版本提供的特性。

或者：

- [ ] 本次 MR **使用了**上游组件（例如框架、后台组件等）的较新版本提供的特性。
- [ ] 在对应的文件中更新了该上游组件的依赖版本（或确认了当前声明的依赖版本已包含本次 MR 使用的新特性）。

## 提交信息检查


### 问题修复：

- [x] 本次 MR 包含问题修复的提交，且该提交不带有新特性或破坏性变更，并使用了 `fix` 作为提交类型。
- [ ] 给问题修复添加了单元测试。
- [x] 手动验证过问题修复得到解决。


## 简单描述

antd textarea里的before伪元素占位，导致展示不对齐