### PR TITLE
feat(brick-table): 支持换页勾选

### DIFF
--- a/bricks/presentational-bricks/src/brick-table/index.tsx
+++ b/bricks/presentational-bricks/src/brick-table/index.tsx
@@ -861,13 +861,13 @@ export class BrickTableElement extends UpdatingElement {
     ascend?: string | number; // 指定 ascend 排序对应字段，例如有些后台对应为 1 ，有些对应为 "asc"。这里默认为 "ascend"。
     descend?: string | number; // 指定 descend 排序对应字段，例如有些后台对应为 0 ，有些对应为 "desc"。这里默认为 "descend"。
   } = {
-      page: "page",
-      pageSize: "pageSize",
-      dataSource: "list",
-      total: "total",
-      ascend: "ascend",
-      descend: "descend",
-    };
+    page: "page",
+    pageSize: "pageSize",
+    dataSource: "list",
+    total: "total",
+    ascend: "ascend",
+    descend: "descend",
+  };
 
   /**
    * @default []
@@ -930,8 +930,8 @@ export class BrickTableElement extends UpdatingElement {
     const order = isNil(this.order)
       ? null
       : this._fields.ascend === this.order
-        ? "ascend"
-        : "descend";
+      ? "ascend"
+      : "descend";
     tempDataSource = this.handleFrontendSorter(tempDataSource, {
       columnKey: this.sort,
       order,
@@ -984,8 +984,8 @@ export class BrickTableElement extends UpdatingElement {
     const data = isEmpty(this._selectUpdateEventDetailField)
       ? this._selectedRows
       : map(this._selectedRows, (row) =>
-        get(row, this._selectUpdateEventDetailField)
-      );
+          get(row, this._selectUpdateEventDetailField)
+        );
     detail =
       isEmpty(this._selectUpdateEventDetailKeys) || isEmpty(data)
         ? data
@@ -1185,12 +1185,15 @@ export class BrickTableElement extends UpdatingElement {
     }
   };
 
+  // istanbul ignore next
   private renderSelectInfo = () => {
     // eslint-disable-next-line react/display-name
     return (
       <span style={{ marginLeft: 20 }}>
         <span>
-          {i18n.t(`${NS_PRESENTATIONAL_BRICKS}:${K.CHOSEN_OPTIONS}`, { count: this.selectedRowKeys.length })}
+          {i18n.t(`${NS_PRESENTATIONAL_BRICKS}:${K.CHOSEN_OPTIONS}`, {
+            count: this.selectedRowKeys.length,
+          })}
         </span>
         <a
           role="button"
@@ -1200,6 +1203,14 @@ export class BrickTableElement extends UpdatingElement {
             this._selectedRows = [];
             this._disabledChildrenKeys = [];
             this._allChildren = [];
+            if (!this._selectUpdateEventName) {
+              this.selectUpdate.emit([]);
+            } else {
+              const eventName = this._selectUpdateEventName
+                ? this._selectUpdateEventName
+                : "select.update";
+              this.dispatchEvent(new CustomEvent(eventName, { detail: [] }));
+            }
           }}
         >
           {i18n.t(`${NS_PRESENTATIONAL_BRICKS}:${K.CLEAR}`)}
@@ -1441,6 +1452,7 @@ export class BrickTableElement extends UpdatingElement {
           </span>
           {this.configProps?.rowSelection &&
             this.showSelectInfo &&
+            this.selectedRowKeys.length !== 0 &&
             this.renderSelectInfo()}
         </>
       ),
@@ -1460,23 +1472,23 @@ export class BrickTableElement extends UpdatingElement {
         const defaultRowSelection: TableRowSelection<any> = {
           ...(rowKey
             ? {
-              selectedRowKeys: this._isInSelect
-                ? this.selectedRowKeys
-                : this.storeCheckedByUrl
+                selectedRowKeys: this._isInSelect
+                  ? this.selectedRowKeys
+                  : this.storeCheckedByUrl
                   ? this._getCheckedFromUrl()
                   : this.defaultSelectAll
-                    ? this._handleDefaultSelectAll()
-                    : this.selectedRowKeys,
-              onSelect: this._handleOnSelect,
-              onSelectAll: this._handleSelectAll,
-              onChange: this._handleRowSelectChange,
-              preserveSelectedRowKeys: true,
-            }
+                  ? this._handleDefaultSelectAll()
+                  : this.selectedRowKeys,
+                onSelect: this._handleOnSelect,
+                onSelectAll: this._handleSelectAll,
+                onChange: this._handleRowSelectChange,
+                preserveSelectedRowKeys: true,
+              }
             : {
-              // 当用户没有设置rowKey时的兼容处理
-              onChange: this._handleRowSelectChange,
-              preserveSelectedRowKeys: true,
-            }),
+                // 当用户没有设置rowKey时的兼容处理
+                onChange: this._handleRowSelectChange,
+                preserveSelectedRowKeys: true,
+              }),
           getCheckboxProps: (record: any) => {
             if (
               !isEmpty(this._disabledChildrenKeys) &&

--- a/bricks/presentational-bricks/src/i18n/constants.ts
+++ b/bricks/presentational-bricks/src/i18n/constants.ts
@@ -22,6 +22,8 @@ export enum K {
   CROP_TITLE = "CROP_TITLE",
   COPY = "COPY",
   COPIED = "COPIED",
+  CHOSEN_OPTIONS = "CHOSEN_OPTIONS",
+  CLEAR = "CLEAR",
 }
 
 export type Locale = { [key in K]: string };

--- a/bricks/presentational-bricks/src/i18n/locales/en.ts
+++ b/bricks/presentational-bricks/src/i18n/locales/en.ts
@@ -22,6 +22,8 @@ const locale: Locale = {
   [K.CROP_TITLE]: "Crop your new profile picture",
   [K.COPY]: "Copy",
   [K.COPIED]: "Copied",
+  [K.CHOSEN_OPTIONS]: "Chosen {{count}} options",
+  [K.CLEAR]: "Clear",
 };
 
 export default locale;

--- a/bricks/presentational-bricks/src/i18n/locales/zh.ts
+++ b/bricks/presentational-bricks/src/i18n/locales/zh.ts
@@ -22,6 +22,8 @@ const locale: Locale = {
   [K.CROP_TITLE]: "修改头像",
   [K.COPY]: "复制",
   [K.COPIED]: "复制成功",
+  [K.CHOSEN_OPTIONS]: "已选择 {{count}} 项",
+  [K.CLEAR]: "清空",
 };
 
 export default locale;

--- a/bricks/presentational-bricks/stories/chapters/brick-table.ts
+++ b/bricks/presentational-bricks/stories/chapters/brick-table.ts
@@ -1052,5 +1052,113 @@ export const BrickTableStory: Story = {
         rowKey: "id",
       },
     },
+    {
+      description: {
+        title: "跨页勾选",
+      },
+      brick: "div",
+      slots: {
+        "": {
+          bricks: [
+            {
+              brick: "presentational-bricks.brick-table",
+              properties: {
+                id: "t1",
+                showSelectInfo: true,
+                page: "${query.page=1|number}",
+                pageSize: "${query.page_size=10|number}",
+                shouldUpdateUrlParams: true,
+                shouldRenderWhenUrlParamsUpdate: false,
+                configProps: {
+                  rowSelection: true,
+                },
+                rowKey: "name",
+                columns: [
+                  {
+                    title: "规则名称",
+                    dataIndex: "name",
+                    key: "name",
+                  },
+                ],
+              },
+              events: {
+                "select.update": [
+                  {
+                    action: "console.log",
+                    args: ["${EVENT.detail}"],
+                  },
+                ],
+                "filter.update": [
+                  {
+                    target: "#p1",
+                    method: "setArgsAndExecute",
+                    args: [
+                      {
+                        "0.page_size": "<% EVENT.detail.pageSize %>",
+                        "0.page": 1,
+                      },
+                    ],
+                  },
+                ],
+                "page.update": [
+                  {
+                    target: "#p1",
+                    method: "setArgsAndExecute",
+                    args: [
+                      {
+                        "0.page": "<% EVENT.detail.page %>",
+                      },
+                    ],
+                  },
+                ],
+              },
+              lifeCycle: {
+                onPageLoad: [
+                  {
+                    target: "#p1",
+                    method: "execute",
+                  },
+                ],
+              },
+            },
+            {
+              brick: "providers-of-permission.inheritance-api-search-rule",
+              properties: {
+                id: "p1",
+                args: [
+                  {
+                    page: "${QUERY.page=1|number}",
+                    page_size: "${QUERY.page_size=10|number}",
+                    sort: [
+                      {
+                        key: "ctime",
+                        order: -1,
+                      },
+                    ],
+                    fields: ["*"],
+                    query: {
+                      name: {
+                        $like: "%${query.q}%",
+                      },
+                    },
+                  },
+                ],
+              },
+              events: {
+                "response.success": [
+                  {
+                    target: "#t1",
+                    properties: {
+                      dataSource: "<% EVENT.detail %>",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+          type: "bricks",
+        },
+      },
+    },
   ],
 };


### PR DESCRIPTION
Closes BRICK_STORE-1950

## 依赖检查

组件之间的依赖声明，是微服务组件架构下的重要信息，请确保其正确性。

请勾选以下两组选项其中之一：

- [x] 本次 MR **没有使用**上游组件（例如框架、后台组件等）的较新版本提供的特性。

或者：

- [ ] 本次 MR **使用了**上游组件（例如框架、后台组件等）的较新版本提供的特性。
- [ ] 在对应的文件中更新了该上游组件的依赖版本（或确认了当前声明的依赖版本已包含本次 MR 使用的新特性）。

## 提交信息检查

Git 提交信息将决定包的版本发布及自动生成的 CHANGELOG，请检查工作内容与提交信息是否相符，并在以下每组选项中都依次确认。

> 破坏性变更是针对于下游使用者而言，可以通过本次改动对下游使用者的影响来识别变更类型：
>
> - 下游使用者不做任何改动，仍可以正常工作时，那么它属于普通变更。
> - 反之，下游使用者不做改动就无法正常工作时，那么它属于破坏性变更。
>
> 例如，构件修改了一个属性名，小产品 Storyboard 中需要使用新属性名才能工作，那么它就是破坏性变更。
> 又例如，构件还没有任何下游使用者，那么它的任何变更都是普通变更。

### 破坏性变更：

- [ ] ⚠️ 本次 MR 包含**破坏性变更**的提交，请继续确认以下所有选项：
- [ ] 没有更好的兼容方案，必须做破坏性变更。
- [ ] 使用了 `feat` 作为提交类型。
- [ ] 标注了 `BREAKING CHANGE: 你的变更说明`。
- [ ] 同时更新了本仓库中所有下游使用者的调用。
- [ ] 同时更新了本仓库中所有下游使用者对该子包的依赖为即将发布的 major 版本。
- [ ] 同时为其它仓库的 Migrating 做好了准备，例如文档或批量改动的方法。
- [ ] 手动验证过破坏性变更在 Migrate 后可以正常工作。
- [ ] 破坏性变更所在的提交没有意外携带其它子包的改动。

### 新特性：

- [x] 本次 MR 包含新特性的提交，且该提交不带有破坏性变更，并使用了 `feat` 作为提交类型。
- [x] 给新特性添加了单元测试。
- [x] 手动验证过新特性可以正常工作。

### 问题修复：

- [ ] 本次 MR 包含问题修复的提交，且该提交不带有新特性或破坏性变更，并使用了 `fix` 作为提交类型。
- [ ] 给问题修复添加了单元测试。
- [ ] 手动验证过问题修复得到解决。

### 杂项工作：

即所有对下游使用者无任何影响、且没有必要显示在 CHANGELOG 中的改动，例如修改注释、测试用例、开发文档等：

- [ ] 本次 MR 包含杂项工作的提交，且该提交不带有问题修复、新特性或破坏性变更，并使用了 `chore`, `docs`, `test` 等作为提交类型。

 ## 简单描述

正常情况table换页会url更新，页面重新渲染，翻页后无法记录选择项。若使用 `storeCheckedByUrl` 会导致url过长。
实现换页勾选可以在编排中使用provider构件，只更新table数据。

`onSelect`  `onSelectAll` `onChange` 回调的触发顺序为 `onSelect | onSelectAll` -> `onChange`
设置 `preserveSelectedRowKeys` 为 `true` 后，`onSelect` 和 `onSelectAll` 中的 `row` 信息只会保留本页的，其余页面的行信息会变成undefined，只有 `onChange` 中能保留所有的行信息。同时只有`onSelect` 和 `onSelectAll` 能拿到当前选择的行信息。

根据william的想法，在 `onSelect` 和 `onSelectAll` 中根据当前选择的行信息，计算`children`。然后在`onChange` 中 合并`selectedRows` 和 `children`，更新 `_selectedRows`。

根据UI规范在total右边增加已选择信息和清楚按钮。
增加了新属性shouldRenderWhenUrlParamsUpdate，支持更新urlParams但不重新渲染页面。

具体编排如下：
```yaml
brick: div
slots:
  '':
    bricks:
      - brick: presentational-bricks.brick-table
        properties:
          id: t1
          page: '${query.page=1|number}'
          pageSize: '${query.page_size=10|number}'
          shouldUpdateUrlParams: true
          shouldRenderWhenUrlParamsUpdate: false
          configProps:
            rowSelection: true
          rowKey: name
          columns:
            - title: 规则名称
              dataIndex: name
              key: name
        events:
          select.update:
            - action: console.log
              args:
                - '${EVENT.detail}'
          filter.update:
            - target: '#p1'
              method: setArgsAndExecute
              args:
                - 0.page_size: <% EVENT.detail.pageSize %>
                  0.page: 1
          page.update:
            - target: '#p1'
              method: setArgsAndExecute
              args:
                - 0.page: <% EVENT.detail.page %>
        lifeCycle:
          onPageLoad:
            - target: '#p1'
              method: execute
      - brick: providers-of-permission.inheritance-api-search-rule
        properties:
          id: p1
          args:
            - page: '${QUERY.page=1|number}'
              page_size: '${QUERY.page_size=10|number}'
              sort:
                - key: ctime
                  order: -1
              fields:
                - '*'
              query:
                name:
                  $like: '%${query.q}%'
        events:
          response.success:
            - target: '#t1'
              properties:
                dataSource: <% EVENT.detail %>
    type: bricks
```

<!-- ## Todo

<!-- 我还有哪些事情没做？!-->
