### PR TITLE
Revert "fix(general-signup): encrypt password only when using AuthApi_register"

### DIFF
--- a/bricks/general-auth/src/general-signup/GeneralSignup.tsx
+++ b/bricks/general-auth/src/general-signup/GeneralSignup.tsx
@@ -175,6 +175,7 @@ export function GeneralSignup(props: GeneralSignupProps): React.ReactElement {
   };
 
   const onFinish = async (values: Record<string, any>): Promise<void> => {
+    values.password = encryptValue(values.password);
     try {
       let result: Record<string, any>;
       if (isCommonSignup && !hideInvite) {
@@ -184,7 +185,6 @@ export function GeneralSignup(props: GeneralSignupProps): React.ReactElement {
           }) as OrgApi_SaaSOrgRegisterRequestBody
         );
       } else {
-        values.password = encryptValue(values.password);
         result = await AuthApi_register(
           assign(
             omit(values, ["terms", "password2", "username"]),


### PR DESCRIPTION
Reverts easyops-cn/next-basics#1548