### PR TITLE
feat(): node name suffix 支持只展示数据不相应点击事件

### DIFF
--- a/bricks/next-builder/src/workbench-data-tree/WorkbenchDataTree.tsx
+++ b/bricks/next-builder/src/workbench-data-tree/WorkbenchDataTree.tsx
@@ -32,6 +32,7 @@ export interface WorkbenchDataTreeProps extends ContextOfWorkbenchTree {
   dropEmit?: (detail: dropEmitProps) => void;
   matchNodeDataFields?: string | string[];
   onNodeNameSuffixClick?: (node: WorkbenchNodeData) => void;
+  disabledNodeSuffixClick?: boolean;
 }
 
 export function WorkbenchDataTree({
@@ -41,6 +42,7 @@ export function WorkbenchDataTree({
   dropEmit,
   activeKey,
   nodeKey,
+  disabledNodeSuffixClick,
   clickFactory,
   contextMenuFactory,
   matchNodeDataFields,
@@ -132,7 +134,11 @@ export function WorkbenchDataTree({
       }}
     >
       <RealTimeDataContext.Provider
-        value={{ realTimeDataValues, isUpdate, onClick: onNodeNameSuffixClick }}
+        value={{
+          realTimeDataValues,
+          isUpdate,
+          onClick: disabledNodeSuffixClick ? null : onNodeNameSuffixClick,
+        }}
       >
         <WorkbenchTree
           nodes={trees}

--- a/bricks/next-builder/src/workbench-data-tree/index.tsx
+++ b/bricks/next-builder/src/workbench-data-tree/index.tsx
@@ -74,6 +74,9 @@ export class WorkbenchDataTreeElement extends UpdatingElement {
   @property({ type: String })
   nodeKey: string;
 
+  @property({ type: Boolean })
+  disabledNodeSuffixClick: boolean;
+
   @event({ type: "action.click" })
   private _actionClickEvent: EventEmitter<ActionClickDetail>;
 
@@ -150,6 +153,7 @@ export class WorkbenchDataTreeElement extends UpdatingElement {
                 dropEmit={this._handleNodeDrop}
                 activeKey={this.activeKey}
                 nodeKey={this.nodeKey}
+                disabledNodeSuffixClick={this.disabledNodeSuffixClick}
                 clickFactory={this._nodeClickFactory}
                 contextMenuFactory={this._contextMenuFactory}
                 matchNodeDataFields={this.matchNodeDataFields}


### PR DESCRIPTION
## 依赖检查

组件之间的依赖声明，是微服务组件架构下的重要信息，请确保其正确性。

请勾选以下两组选项其中之一：

- [x] 本次 MR **没有使用**上游组件（例如框架、后台组件等）的较新版本提供的特性。

或者：

- [ ] 本次 MR **使用了**上游组件（例如框架、后台组件等）的较新版本提供的特性。
- [ ] 在对应的文件中更新了该上游组件的依赖版本（或确认了当前声明的依赖版本已包含本次 MR 使用的新特性）。

## 提交信息检查

Git 提交信息将决定包的版本发布及自动生成的 CHANGELOG，请检查工作内容与提交信息是否相符，并在以下每组选项中都依次确认。

> 破坏性变更是针对于下游使用者而言，可以通过本次改动对下游使用者的影响来识别变更类型：
>
> - 下游使用者不做任何改动，仍可以正常工作时，那么它属于普通变更。
> - 反之，下游使用者不做改动就无法正常工作时，那么它属于破坏性变更。
>
> 例如，构件修改了一个属性名，小产品 Storyboard 中需要使用新属性名才能工作，那么它就是破坏性变更。
> 又例如，构件还没有任何下游使用者，那么它的任何变更都是普通变更。

### 破坏性变更：

- [ ] ⚠️ 本次 MR 包含**破坏性变更**的提交，请继续确认以下所有选项：
- [ ] 没有更好的兼容方案，必须做破坏性变更。
- [ ] 使用了 `feat` 作为提交类型。
- [ ] 标注了 `BREAKING CHANGE: 你的变更说明`。
- [ ] 同时更新了本仓库中所有下游使用者的调用。
- [ ] 同时更新了本仓库中所有下游使用者对该子包的依赖为即将发布的 major 版本。
- [ ] 同时为其它仓库的 Migrating 做好了准备，例如文档或批量改动的方法。
- [ ] 手动验证过破坏性变更在 Migrate 后可以正常工作。
- [ ] 破坏性变更所在的提交没有意外携带其它子包的改动。

### 新特性：

- [x] 本次 MR 包含新特性的提交，且该提交不带有破坏性变更，并使用了 `feat` 作为提交类型。
- [ ] 给新特性添加了单元测试。
- [x] 手动验证过新特性可以正常工作。

### 问题修复：

- [ ] 本次 MR 包含问题修复的提交，且该提交不带有新特性或破坏性变更，并使用了 `fix` 作为提交类型。
- [ ] 给问题修复添加了单元测试。
- [ ] 手动验证过问题修复得到解决。

### 杂项工作：

即所有对下游使用者无任何影响、且没有必要显示在 CHANGELOG 中的改动，例如修改注释、测试用例、开发文档等：

- [ ] 本次 MR 包含杂项工作的提交，且该提交不带有问题修复、新特性或破坏性变更，并使用了 `chore`, `docs`, `test` 等作为提交类型。

## 简单描述

![image](https://github.com/easyops-cn/next-basics/assets/24582340/527aa1d9-27d8-4e59-acd0-f6e539cb9a26)

右侧 annotation希望只展示，目前的交互是点数据弹出编辑框，点击右侧的 annotation 弹出数据预览框，现在改为整个项
点击时都弹出编辑框，目前不配置事件时因为组件内部会阻止冒泡，点击不会没有弹出编辑框，这里通过增加一个属性控制
![image](https://github.com/easyops-cn/next-basics/assets/24582340/23bfa314-7d66-4710-9923-c1460dfcd1e7)

