### PR TITLE
fix(forms): 修复回显文件下载按钮不显示的问题

### DIFF
--- a/bricks/forms/src/upload-files-v2/UploadFilesV2.spec.tsx
+++ b/bricks/forms/src/upload-files-v2/UploadFilesV2.spec.tsx
@@ -264,6 +264,29 @@ describe("UploadFilesV2", () => {
     expect(wrapper.find(".ant-upload-list-item").length).toBe(2);
   });
 
+  it("回显的文件应补上 status=done 以显示下载按钮", async () => {
+    const wrapper = mount(
+      <UploadFilesV2
+        url={url}
+        method="put"
+        value={[
+          {
+            uid: "-echo1",
+            name: "echo.png",
+            url: "echo.png",
+          },
+        ]}
+        showDownloadIcon
+      />
+    );
+    await act(async () => {
+      await jest.runAllTimers();
+    });
+    wrapper.update();
+    const listItem = wrapper.find("UploadList").prop("items");
+    expect((listItem as any[])[0].status).toBe("done");
+  });
+
   it("test maxNumber", async () => {
     const onChange = jest.fn();
     const wrapper = mount(

--- a/bricks/forms/src/upload-files-v2/UploadFilesV2.tsx
+++ b/bricks/forms/src/upload-files-v2/UploadFilesV2.tsx
@@ -69,6 +69,8 @@ export function addUid(value: UploadFileValueItem[]): FileItem[] {
   let fileList: FileItem[] = [];
   fileList = map(value, (file) => {
     file.uid = file.uid ?? uniqueId("-file");
+    // 回显文件需要标记为 done，否则 antd UploadList 不会渲染下载图标
+    file.status = file.status ?? "done";
     return file;
   });
   return fileList;


### PR DESCRIPTION
通过 form values 回显的文件没有 status 字段，而 antd UploadList 只有在 file.status === 'done' 时才会渲染下载图标，导致回显的文件无法下载。
在 addUid 中给回显文件补上 status=done 的默认值。

## 依赖检查

组件之间的依赖声明，是微服务组件架构下的重要信息，请确保其正确性。

请勾选以下两组选项其中之一：

- [x] 本次 MR **没有使用**上游组件（例如框架、后台组件等）的较新版本提供的特性。

或者：

- [ ] 本次 MR **使用了**上游组件（例如框架、后台组件等）的较新版本提供的特性。
- [ ] 在对应的文件中更新了该上游组件的依赖版本（或确认了当前声明的依赖版本已包含本次 MR 使用的新特性）。

## 提交信息检查

Git 提交信息将决定包的版本发布及自动生成的 CHANGELOG，请检查工作内容与提交信息是否相符，并在以下每组选项中都依次确认。

> 破坏性变更是针对于下游使用者而言，可以通过本次改动对下游使用者的影响来识别变更类型：
>
> - 下游使用者不做任何改动，仍可以正常工作时，那么它属于普通变更。
> - 反之，下游使用者不做改动就无法正常工作时，那么它属于破坏性变更。
>
> 例如，构件修改了一个属性名，小产品 Storyboard 中需要使用新属性名才能工作，那么它就是破坏性变更。
> 又例如，构件还没有任何下游使用者，那么它的任何变更都是普通变更。

### 破坏性变更：

- [ ] ⚠️ 本次 MR 包含**破坏性变更**的提交，请继续确认以下所有选项：
- [ ] 没有更好的兼容方案，必须做破坏性变更。
- [ ] 使用了 `feat` 作为提交类型。
- [ ] 标注了 `BREAKING CHANGE: 你的变更说明`。
- [ ] 同时更新了本仓库中所有下游使用者的调用。
- [ ] 同时更新了本仓库中所有下游使用者对该子包的依赖为即将发布的 major 版本。
- [ ] 同时为其它仓库的 Migrating 做好了准备，例如文档或批量改动的方法。
- [ ] 手动验证过破坏性变更在 Migrate 后可以正常工作。
- [ ] 破坏性变更所在的提交没有意外携带其它子包的改动。

### 新特性：

- [ ] 本次 MR 包含新特性的提交，且该提交不带有破坏性变更，并使用了 `feat` 作为提交类型。
- [ ] 给新特性添加了单元测试。
- [ ] 手动验证过新特性可以正常工作。

### 问题修复：

- [x] 本次 MR 包含问题修复的提交，且该提交不带有新特性或破坏性变更，并使用了 `fix` 作为提交类型。
- [x] 给问题修复添加了单元测试。
- [x] 手动验证过问题修复得到解决。

### 杂项工作：

即所有对下游使用者无任何影响、且没有必要显示在 CHANGELOG 中的改动，例如修改注释、测试用例、开发文档等：

- [ ] 本次 MR 包含杂项工作的提交，且该提交不带有问题修复、新特性或破坏性变更，并使用了 `chore`, `docs`, `test` 等作为提交类型。

<!-- ## 简单描述

<!-- 我在这个 MR 里都做了哪些工作？!-->

<!-- ## Todo

<!-- 我还有哪些事情没做？!-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复通过回显数据展示的文件缺少上传状态时，文件列表显示异常的问题。
  * 现在，已完成上传的回显文件会正确显示下载按钮等相关操作界面。
  * 新增测试，确保文件状态能够稳定识别为“已完成”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->